### PR TITLE
Enable light mode by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -56,7 +56,7 @@ function toggleTheme() {
   localStorage.setItem('minikanban/theme', next);
 }
 onMounted(() => {
-  const theme = localStorage.getItem('minikanban/theme') || 'dark';
+  const theme = localStorage.getItem('minikanban/theme') || 'light';
   document.documentElement.setAttribute('data-theme', theme);
 });
 </script>


### PR DESCRIPTION
Set light mode as the default theme to align with user preference and prevent a dark mode flash on initial load.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff40fbcf-0401-45d8-97c2-375a5609b12e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff40fbcf-0401-45d8-97c2-375a5609b12e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

